### PR TITLE
Long running process exits with ProcessTimedOutException

### DIFF
--- a/engine.php
+++ b/engine.php
@@ -37,6 +37,7 @@ else {
 $phpcs_config_options = implode(' ',$extra_config_options);
 
 $process = new Process("./vendor/bin/phpcs $phpcs_config_options /code");
+$process->setTimeout(null);
 $process->run();
 
 $phpcs_output = json_decode($process->getOutput(), true);

--- a/engine.php
+++ b/engine.php
@@ -37,7 +37,7 @@ else {
 $phpcs_config_options = implode(' ',$extra_config_options);
 
 $process = new Process("./vendor/bin/phpcs $phpcs_config_options /code");
-$process->setTimeout(null);
+$process->setTimeout(10 * 60); // 600 sec = 10 minutes max runtime as per spec
 $process->run();
 
 $phpcs_output = json_decode($process->getOutput(), true);


### PR DESCRIPTION
The default timeout of Symphony Process seems to be [60 seconds](https://github.com/symfony/Process/blob/master/Process.php#L145) so a long running check times out with an exception after a minute.

This change removes the timeout altogether.