### PR TITLE
Fix Issue #8: Configuration not always being honored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 COPY composer.json /usr/src/app/
 COPY composer.lock /usr/src/app/
 
-RUN apk --update add git php-common php-iconv php-json php-phar php-openssl curl && \
+RUN apk --update add git php-common php-ctype php-iconv php-json php-phar php-openssl curl && \
     curl -sS https://getcomposer.org/installer | php && \
     /usr/src/app/composer.phar install && \
     apk del build-base && rm -fr /usr/share/ri


### PR DESCRIPTION
- Part of the issue was max arg length, which converting to calling the class directly fixes
- Removed custom_exclude_paths from possible config options
- Simpified the output parsing
- Add php-ctype, as it appears phpcs needs this when processing javascript files (was getting errors)