### PR TITLE
rm extra space in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Format the values for these config options per the [PHP_CodeSniffer documentatio
         enabled: true
         config:
           file_extensions: "php,inc,lib"
-          standard: "PSR1, PSR2"
+          standard: "PSR1,PSR2"
           ignore_warnings: true
     ratings:
       paths:


### PR DESCRIPTION
[The config](https://github.com/codeclimate/codeclimate-phpcodesniffer/blob/a487277099a2267b1b5981bfab4d39fa2f6e7d40/.codeclimate.yml) we use [was recently changed](https://github.com/codeclimate/codeclimate-phpcodesniffer/commit/a487277099a2267b1b5981bfab4d39fa2f6e7d40). README should probably match it.