### PR TITLE
Temporarily use lowercased version of G Cloud key

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ deployment:
     branch: master
     owner: codeclimate
     commands:
-      - echo $GCLOUD_JSON_KEY_BASE64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+      - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
       - curl https://sdk.cloud.google.com | bash
       - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
       - gcloud docker -a


### PR DESCRIPTION
Moving forward, we should use the uppercase version, but permissions are tricky.