### PR TITLE
Use `include_paths` to determine files to analyze

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -19,12 +19,7 @@ class Runner
     {
         chdir("/code");
 
-        if(isset($this->config['include_paths'])) {
-            $this->queueWithIncludePaths();
-        } else {
-            $this->queuePaths($dir, $prefix, $this->config['exclude_paths']);
-        }
-
+        $this->queueWithIncludePaths();
         $this->server->process_work(false);
     }
 
@@ -40,17 +35,13 @@ class Runner
         }
     }
 
-    public function queuePaths($dir, $prefix = '', $exclusions = []) {
+    public function queuePaths($dir, $prefix = '') {
         $dir = rtrim($dir, '\\/');
 
         foreach (scandir($dir) as $f) {
-            if (in_array("$prefix$f", $exclusions)) {
-                continue;
-            }
-
             if ($f !== '.' and $f !== '..') {
                 if (is_dir("$dir/$f")) {
-                    $this->queuePaths("$dir/$f", "$prefix$f/", $exclusions);
+                    $this->queuePaths("$dir/$f", "$prefix$f/");
                 } else {
                     $this->filterByExtension($f, $prefix);
                 }


### PR DESCRIPTION
This removes the check for the inclusion of `include_paths` in favor of
always using `include_paths`. This is because the use of `exclude_paths`
for engines has been deprecated.