### PR TITLE
Fix path replacement

### DIFF
--- a/engine.php
+++ b/engine.php
@@ -42,7 +42,7 @@ foreach ($server->get_all_results() as $result_file) {
                         'description' => $phpcs_issue_data['message'],
                         'categories' => array('Style'),
                         'location' => array(
-                            'path' => str_replace('/code/', '', $phpcs_file),
+                            'path' => preg_replace('/^\/code\//', '', $phpcs_file),
                             'lines' => array(
                                 'begin' => $phpcs_issue_data['line'],
                                 'end' => $phpcs_issue_data['line']


### PR DESCRIPTION
Previously we were searching for all instances of "/code" to an empty
string for reporting back to Code Climate. This was resulting in any
file that had a nested directory called "code" to be replaced which
created issues with display.

Change the replacement of "/code" to a regular expression that anchors
the pattern so that we only replace the first instance.