### PR TITLE
Add PHPCS encoding argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Format the values for these config options per the [PHP_CodeSniffer documentatio
 * file_extensions - This is where you can configure the file extensions for the files that you want PHP_CodeSniffer to analyze.
 * standard - This is the list of standards that you want PHP_CodeSniffer to use while analyzing your files.
 * ignore_warnings - You can hide warnings, and only report errors with this option.
+* encoding - By default, PHPCS uses ISO-8859-1. Use this to change it to your encoding, e.g. UTF-8.
 
 ###Sample Config
 
@@ -29,6 +30,7 @@ Format the values for these config options per the [PHP_CodeSniffer documentatio
           file_extensions: "php,inc,lib"
           standard: "PSR1,PSR2"
           ignore_warnings: true
+          encoding: utf-8
     ratings:
       paths:
       - "**.php"

--- a/Runner.php
+++ b/Runner.php
@@ -93,6 +93,10 @@ class Runner
             $extra_config_options[] = '-n';
         }
 
+        if (isset($this->config['config']['encoding'])) {
+            $extra_config_options[] = '--encoding=' . $this->config['config']['encoding'];
+        }
+
         foreach ($files as $file) {
             $extra_config_options[] = $file;
         }


### PR DESCRIPTION
This adds the option to specify the encoding: https://pear.php.net/manual/en/package.php.php-codesniffer.config-options.php

I'm hoping this resolves the error I'm having on this build: https://codeclimate.com/github/josephdpurcell/drupal/builds/8

```
PHP Notice:  iconv_strlen(): Detected an illegal character in input string in /usr/src/app/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php on line 1514
```