### PR TITLE
Exit with code 1 if an exception is raised while analyzing

### DIFF
--- a/engine.php
+++ b/engine.php
@@ -28,6 +28,12 @@ $runner->queueDirectory("/code");
 $server->process_work(true);
 
 // Process results
+
+// If there is no output from the runner, an exception must have occurred
+if (count($server->get_all_results()) == 0) {
+    exit(1);
+}
+
 foreach ($server->get_all_results() as $result_file) {
     $phpcs_output = json_decode(file_get_contents($result_file), true);
     unlink($result_file);


### PR DESCRIPTION
forkdaemon doesn't bubble up child errors, as they are separate
processes, but we can catch them, log them, and then return false
instead of returning a file containing the PHPCS results.

Info on forkdaemon behavior:
https://github.com/barracudanetworks/forkdaemon-php/issues/26

@codeclimate/review 