### PR TITLE
Return string when error is thrown

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -122,7 +122,7 @@ class Runner
             return $resultFile;
         } catch (Exception $e) {
             error_log("Exception: " . $e->getMessage() . " in " . $e->getFile() . "\n" . $e->getTraceAsString());
-            return false;
+            return $e;
         }
     }
 }

--- a/engine.php
+++ b/engine.php
@@ -31,12 +31,11 @@ $server->process_work(true);
 
 $results = $server->get_all_results();
 
-// If there is no output from the runner, an exception must have occurred
-if (count($results) == 0) {
-    exit(1);
-}
-
 foreach ($results as $result_file) {
+    if (is_a($result_file, "Exception")) {
+        exit(1);
+    }
+
     $phpcs_output = json_decode(file_get_contents($result_file), true);
     unlink($result_file);
 


### PR DESCRIPTION
The previous solution caused an error when no files were analyzed, so
return a special string if anything errors.

@codeclimate/review 