### PR TITLE
 Fix unescaped unicode encoding parameter

### DIFF
--- a/engine.php
+++ b/engine.php
@@ -59,7 +59,7 @@ foreach ($results as $result_file) {
                     );
                     file_put_contents(
                         'php://stdout',
-                        json_encode($cleaned_single_issue, JSON_UNESCAPED_SLASHES, JSON_UNESCAPED_UNICODE)
+                        json_encode($cleaned_single_issue, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
                     );
                     file_put_contents('php://stdout', chr(0));
                 }


### PR DESCRIPTION
3rd parameter for json_encode is a max depth limitation. `JSON_UNESCAPED_UNICODE` has an int value of 256 whereas the max depth value is 512 (so no matter this way). This patch restores the expected usage of UNESCAPED_UNICODE param which is to
encode multibyte Unicode characters literally.