### PR TITLE
Fix uncatchable exception

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -1,5 +1,6 @@
 <?php
 
+use Exception;
 use Stringy\Stringy as S;
 
 class Runner


### PR DESCRIPTION
L124
```        } catch (Exception $e) { // can't be catched because CodeClimate\PHPMD\Exception does not exist```
Another way to fix this is:
```        } catch (\Exception $e) {```