### PR TITLE
Fixes exception bubbling for php7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,15 @@ RUN apk --update add \
       php7-openssl \
       php7-pcntl \
       php7-phar \
+      php7-simplexml \
       php7-sockets \
+      php7-tokenizer \
+      php7-xml \
+      php7-xmlwriter \
       curl \
       git && \
     rm /var/cache/apk/* && \
-    ln -s /usr/bin/php7 /usr/bin/php
+    ln -sf /usr/bin/php7 /usr/bin/php
 
 RUN adduser -u 9000 -D app
 

--- a/Runner.php
+++ b/Runner.php
@@ -120,7 +120,7 @@ class Runner
             }
 
             return $resultFile;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             error_log("Exception: " . $e->getMessage() . " in " . $e->getFile() . "\n" . $e->getTraceAsString());
             return $e;
         }

--- a/engine.php
+++ b/engine.php
@@ -32,7 +32,7 @@ $server->process_work(true);
 $results = $server->get_all_results();
 
 foreach ($results as $result_file) {
-    if (is_a($result_file, "Exception")) {
+    if (is_a($result_file, "Throwable")) {
         exit(1);
     }
 


### PR DESCRIPTION
Same idea as https://github.com/codeclimate/codeclimate-phpmd/pull/39 with Dockerfile fixes from https://github.com/codeclimate/codeclimate-phpmd/pull/37 to enable image building.

Need to rescue `\Throwable` instead of `Exception` to capture both `Exception` and `Error` (new in php7) objects.
