### PR TITLE
Update WordPress Coding Standards to Version `0.13.1`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "danielstjules/stringy": "^2.3",
         "drupal/coder": "^8.2",
         "escapestudios/symfony2-coding-standard": "^2.10",
-        "wp-coding-standards/wpcs": "^0.13.0",
+        "wp-coding-standards/wpcs": "^0.13.1",
         "yiisoft/yii2-coding-standards": "^2.0",
         "magento/marketplace-eqp": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "danielstjules/stringy": "^2.3",
         "drupal/coder": "^8.2",
         "escapestudios/symfony2-coding-standard": "^2.10",
-        "wp-coding-standards/wpcs": "^0.12.0",
+        "wp-coding-standards/wpcs": "^0.13.0",
         "yiisoft/yii2-coding-standards": "^2.0",
         "magento/marketplace-eqp": "^1.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -276,16 +276,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -297,7 +297,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -331,24 +331,24 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.5",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8"
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1f93a8d19b8241617f5074a123e282575b821df8",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/console": "~2.8|~3.0"
@@ -386,7 +386,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-15T12:58:50+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc8fb4a428f775f8a0e53e26b2790037",
+    "content-hash": "dc8dc4af51e3b114af0d7be0cf882243",
     "packages": [
         {
             "name": "barracudanetworks/forkdaemon-php",
@@ -390,23 +390,24 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.12.0",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "300c15796584d6b63f31841daf674886303af573"
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/300c15796584d6b63f31841daf674886303af573",
-                "reference": "300c15796584d6b63f31841daf674886303af573",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "^2.9.0"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "*"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -425,7 +426,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-07-20T20:11:03+00:00"
+            "time": "2017-08-05T16:08:58+00:00"
         },
         {
             "name": "yiisoft/yii2-coding-standards",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc8dc4af51e3b114af0d7be0cf882243",
+    "content-hash": "8f384a4e104e0bcb7e075affca2c4427",
     "packages": [
         {
             "name": "barracudanetworks/forkdaemon-php",


### PR DESCRIPTION
This pull updates the WordPress Coding Standards sniffs to the latest version, `0.13.0`.

This version now supports `PHP_CodeSniffer` `3.*` (see [release notes](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/0.13.0)). However, `escapestudios/symfony2-coding-standard` currently does not, so we can't update to the latest version `PHP_CodeSniffer`. It does appear to be in the works though.