### PR TITLE
Explicitly check ignore_warnings is truthy

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -90,7 +90,7 @@ class Runner
                 $extra_config_options[] = '--standard=PSR1,PSR2';
             }
 
-            if (isset($this->config['config']['ignore_warnings'])) {
+            if (isset($this->config['config']['ignore_warnings']) && $this->config['config']['ignore_warnings']) {
                 $extra_config_options[] = '-n';
             }
 


### PR DESCRIPTION
# Problem

Setting ignore_warnings: false in the .codeclimate.yml does not NOT ignore warnings, i.e. the flag is still set as true.

# Proposed Resolution

Correctly handle this setting such that "ignore_warnings: false" means no `-n` flag is set.

# Impact

The potential impact of this change is anyone out there who had "ignore_warnings: false", will now have that settings take affect, which will impact their scoring.