### PR TITLE
QUA-502: Set base image to alpine:3.13.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.13.7
 
 RUN adduser -u 9000 -D app
 
@@ -20,14 +20,9 @@ RUN apk add --no-cache \
       php7-tokenizer \
       php7-xml \
       php7-xmlwriter \
-      php7-zlib && \
-    EXPECTED_SIGNATURE=$(php -r "echo file_get_contents('https://composer.github.io/installer.sig');") && \
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');") && \
-    [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ] || (echo "Invalid Composer installer signature"; exit 1) && \
-    php composer-setup.php --quiet && \
-    mv composer.phar /usr/local/bin/composer && \
-    rm -r composer-setup.php ~/.composer
+      php7-zlib
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 COPY composer.json composer.lock ./
 


### PR DESCRIPTION
According to what is exposed on [QUA-502](https://codeclimate.atlassian.net/browse/QUA-502) our [latest update](https://github.com/codeclimate/codeclimate-phpcodesniffer/pull/88) introduced new build failures for some of the users using the `stable` channel.

The motivation behind https://github.com/codeclimate/codeclimate-phpcodesniffer/pull/88 was to resolve critical vulnerabilities reported by snyk.

This update to use `alpine:3.13.7` seems to be compliant with snyk.

```
Testing codeclimate/codeclimate-phpcodesniffer:latest...

Organization:      fede-moya
Package manager:   apk
Project name:      docker-image|codeclimate/codeclimate-phpcodesniffer
Docker image:      codeclimate/codeclimate-phpcodesniffer:latest
Platform:          linux/amd64
Base image:        alpine:3.13.7
Licenses:          enabled

✔ Tested 37 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```

I have tested this image locally using different phpcodesniffer's configurations extracted from the users that reported having issues the first time. Still there is change for some user to experience some kind of trouble with this new image. If that happens the plan is to go a case by cases basis to resolve the problem.



