### PR TITLE
fix: Add missing php7-xmlreader to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
       php7-sockets \
       php7-tokenizer \
       php7-xml \
+      php7-xmlreader \
       php7-xmlwriter \
       php7-zlib
 


### PR DESCRIPTION
WordPress Coding Standards sniffs require `XMLReader` support from PHP. 

* Add the missing Alpine package `php7-xmlreader` to `Dockerfile`

Fixes #94