### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
-              us.gcr.io/code-climate/codeclimate-phpcodesniffer:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-phpcodesniffer:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2
@@ -40,6 +39,7 @@ workflows:
     jobs:
       - build
       - release_images:
+          context: Quality
           requires:
             - build
           filters:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: image
+.PHONY: image release
 
 IMAGE_NAME ?= codeclimate/codeclimate-phpcodesniffer
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 composer-update:
 	docker run \
@@ -12,3 +14,7 @@ composer-update:
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-phpcodesniffer:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-phpcodesniffer:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-phpcodesniffer
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 composer-update:
 	docker run \


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.